### PR TITLE
Electra: Add blobs v2 rpc from eip7691

### DIFF
--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -33,8 +33,8 @@ pub use protocol::RequestType;
 
 pub use handler::SubstreamId;
 pub use methods::{
-    BlocksByRangeRequest, BlocksByRootRequest, GoodbyeReason, LightClientBootstrapRequest,
-    ResponseTermination, RpcErrorResponse, StatusMessage,
+    BlobsByRangeRequest, BlobsByRootRequest, BlocksByRangeRequest, BlocksByRootRequest, 
+    GoodbyeReason, LightClientBootstrapRequest, ResponseTermination, RpcErrorResponse, StatusMessage,
 };
 pub use protocol::{max_rpc_size, Protocol, RPCError};
 

--- a/tests/rpc_tests.rs
+++ b/tests/rpc_tests.rs
@@ -334,10 +334,9 @@ async fn test_blobs_by_range_chunked_rpc() {
     .await;
 
     // BlobsByRange Request
-    let rpc_request = RequestType::BlobsByRange(BlobsByRangeRequest {
-        start_slot: 0,
-        count: slot_count,
-    });
+    let rpc_request = RequestType::BlobsByRange(
+        BlobsByRangeRequest::new_v1(0, slot_count)
+    );
 
     // BlocksByRange Response
     let blob = BlobSidecar::<Mainnet>::default();


### PR DESCRIPTION
this pr is adding support for `BlobSidecarsByRootV2` and `BlobSidecarsByRangeV2` rpc with the updated of `MAX_REQUEST_BLOB_SIDECARS` value