### PR TITLE
Reject RPC requests with trailing bytes after the SSZ payload

### DIFF
--- a/src/rpc/codec.rs
+++ b/src/rpc/codec.rs
@@ -2601,4 +2601,177 @@ mod tests {
             err
         );
     }
+
+    /// Trailing bytes after a complete request payload must remain in the source buffer.
+    /// `upgrade_inbound` then drains the stream and rejects them with `InvalidRequest`
+    /// per `phase0/p2p-interface.md`.
+    #[test]
+    fn test_inbound_codec_leaves_trailing_bytes_in_buffer() {
+        let config = Arc::new(Config::mainnet());
+        let protocol = ProtocolId::new(SupportedProtocol::PingV1, Encoding::SSZSnappy);
+        let fork_context = Arc::new(ForkContext::dummy::<Mainnet>(&config, Phase::Phase0));
+
+        let mut wire = BytesMut::new();
+        let mut outbound = SSZSnappyOutboundCodec::<Mainnet>::new(
+            protocol.clone(),
+            config.max_payload_size,
+            fork_context.clone(),
+        );
+        outbound
+            .encode(RequestType::Ping(Ping { data: 1 }), &mut wire)
+            .expect("Ping encodes");
+
+        let trailing = [0xDEu8; 16];
+        wire.extend_from_slice(&trailing);
+
+        let mut inbound = SSZSnappyInboundCodec::<Mainnet>::new(
+            config.clone_arc(),
+            protocol,
+            config.max_payload_size,
+            fork_context,
+        );
+        let request = inbound
+            .decode(&mut wire)
+            .expect("decode succeeds")
+            .expect("returns a request");
+        assert!(matches!(request, RequestType::Ping(_)));
+        assert_eq!(
+            wire.len(),
+            trailing.len(),
+            "codec must leave trailing bytes in source buffer for drain check",
+        );
+    }
+
+    /// FramedRead-level: trailing bytes after a clean request are detected on the next poll,
+    /// matching what `upgrade_inbound`'s post-decode drain observes.
+    #[tokio::test]
+    async fn test_framed_read_yields_extra_chunk_when_trailing_bytes() {
+        use futures::StreamExt as _;
+        use tokio_util::codec::FramedRead;
+
+        let config = Arc::new(Config::mainnet());
+        let protocol = ProtocolId::new(SupportedProtocol::PingV1, Encoding::SSZSnappy);
+        let fork_context = Arc::new(ForkContext::dummy::<Mainnet>(&config, Phase::Phase0));
+
+        let mut wire = BytesMut::new();
+        let mut outbound = SSZSnappyOutboundCodec::<Mainnet>::new(
+            protocol.clone(),
+            config.max_payload_size,
+            fork_context.clone(),
+        );
+        outbound
+            .encode(RequestType::Ping(Ping { data: 1 }), &mut wire)
+            .expect("Ping encodes");
+        wire.extend_from_slice(&[0xDEu8; 16]);
+
+        let cursor = std::io::Cursor::new(wire.freeze());
+        let codec = SSZSnappyInboundCodec::<Mainnet>::new(
+            config.clone_arc(),
+            protocol,
+            config.max_payload_size,
+            fork_context,
+        );
+        let mut framed = FramedRead::new(cursor, codec);
+
+        let first = framed.next().await;
+        assert!(
+            matches!(first, Some(Ok(RequestType::Ping(_)))),
+            "first item must decode as Ping, got {first:?}",
+        );
+
+        let second = framed.next().await;
+        assert!(
+            second.is_some(),
+            "trailing bytes after request must yield a second item, got None",
+        );
+    }
+
+    /// FramedRead-level: a clean request stream reaches EOF on the next poll, so
+    /// `upgrade_inbound`'s drain returns `Ok(None)` and accepts the request.
+    #[tokio::test]
+    async fn test_framed_read_reaches_eof_on_clean_request() {
+        use futures::StreamExt as _;
+        use tokio_util::codec::FramedRead;
+
+        let config = Arc::new(Config::mainnet());
+        let protocol = ProtocolId::new(SupportedProtocol::PingV1, Encoding::SSZSnappy);
+        let fork_context = Arc::new(ForkContext::dummy::<Mainnet>(&config, Phase::Phase0));
+
+        let mut wire = BytesMut::new();
+        let mut outbound = SSZSnappyOutboundCodec::<Mainnet>::new(
+            protocol.clone(),
+            config.max_payload_size,
+            fork_context.clone(),
+        );
+        outbound
+            .encode(RequestType::Ping(Ping { data: 1 }), &mut wire)
+            .expect("Ping encodes");
+
+        let cursor = std::io::Cursor::new(wire.freeze());
+        let codec = SSZSnappyInboundCodec::<Mainnet>::new(
+            config.clone_arc(),
+            protocol,
+            config.max_payload_size,
+            fork_context,
+        );
+        let mut framed = FramedRead::new(cursor, codec);
+
+        let first = framed.next().await;
+        assert!(matches!(first, Some(Ok(RequestType::Ping(_)))));
+
+        let second = framed.next().await;
+        assert!(
+            second.is_none(),
+            "clean request must reach EOF, got {second:?}",
+        );
+    }
+
+    /// Same as the Ping trailing-bytes test, but for a variable-size request
+    /// (`BlocksByRootV2`). Variable-size SSZ goes through a different decode branch
+    /// than fixed-size Ping; the drain check must work for both.
+    #[tokio::test]
+    async fn test_framed_read_yields_extra_chunk_when_trailing_bytes_blocks_by_root() {
+        use futures::StreamExt as _;
+        use tokio_util::codec::FramedRead;
+
+        let config = Arc::new(Config::mainnet());
+        let phase = Phase::Phase0;
+        let protocol = ProtocolId::new(SupportedProtocol::BlocksByRootV2, Encoding::SSZSnappy);
+        let fork_context = Arc::new(ForkContext::dummy::<Mainnet>(&config, phase));
+
+        let mut wire = BytesMut::new();
+        let mut outbound = SSZSnappyOutboundCodec::<Mainnet>::new(
+            protocol.clone(),
+            config.max_payload_size,
+            fork_context.clone(),
+        );
+        outbound
+            .encode(
+                RequestType::BlocksByRoot(bbroot_request_v2(&config, phase)),
+                &mut wire,
+            )
+            .expect("BlocksByRoot encodes");
+        wire.extend_from_slice(&[0xDEu8; 16]);
+
+        let cursor = std::io::Cursor::new(wire.freeze());
+        let codec = SSZSnappyInboundCodec::<Mainnet>::new(
+            config.clone_arc(),
+            protocol,
+            config.max_payload_size,
+            fork_context,
+        );
+        let mut framed = FramedRead::new(cursor, codec);
+
+        let first = framed.next().await;
+        assert!(
+            matches!(first, Some(Ok(RequestType::BlocksByRoot(_)))),
+            "first item must decode as BlocksByRoot, got {first:?}",
+        );
+
+        let second = framed.next().await;
+        assert!(
+            second.is_some(),
+            "trailing bytes after request must yield a second item, got None",
+        );
+    }
 }

--- a/src/rpc/protocol.rs
+++ b/src/rpc/protocol.rs
@@ -84,6 +84,10 @@ const PROTOCOL_PREFIX: &str = "/eth2/beacon_chain/req";
 /// The number of seconds to wait for the first bytes of a request once a protocol has been
 /// established before the stream is terminated.
 const REQUEST_TIMEOUT: u64 = 15;
+/// After decoding a request, the peer is expected to have closed the write side of the stream.
+/// Wait up to this duration for EOF so we can reject trailing bytes per
+/// `phase0/p2p-interface.md` (`InvalidRequest` on any remaining bytes after the SSZ payload).
+const REQUEST_TRAILING_BYTES_TIMEOUT: Duration = Duration::from_millis(500);
 
 /// Returns the rpc limits for beacon_block_by_range and beacon_block_by_root responses.
 ///
@@ -633,7 +637,28 @@ where
                     .await
                     {
                         Err(e) => Err((versioned_protocol.protocol(), RPCError::from(e))),
-                        Ok((Some(Ok(request)), stream)) => Ok((request, stream)),
+                        Ok((Some(Ok(request)), mut stream)) => {
+                            match tokio::time::timeout(
+                                REQUEST_TRAILING_BYTES_TIMEOUT,
+                                stream.next(),
+                            )
+                            .await
+                            {
+                                Ok(None) => Ok((request, stream)),
+                                Ok(Some(_)) => Err((
+                                    versioned_protocol.protocol(),
+                                    RPCError::InvalidData(
+                                        "trailing bytes after request payload".into(),
+                                    ),
+                                )),
+                                Err(_) => Err((
+                                    versioned_protocol.protocol(),
+                                    RPCError::InvalidData(
+                                        "request stream not closed after request payload".into(),
+                                    ),
+                                )),
+                            }
+                        }
                         Ok((Some(Err(e)), _)) => Err((versioned_protocol.protocol(), e)),
                         Ok((None, _)) => {
                             Err((versioned_protocol.protocol(), RPCError::IncompleteStream))


### PR DESCRIPTION
## Summary

Per `consensus-specs/specs/phase0/p2p-interface.md`:

> A reader MUST consider the following cases as invalid input:
> - Any remaining bytes, after having read the `n` SSZ bytes.
>
> In case of an invalid input (header or payload), a reader MUST:
> - From requests: send back an error message, response code `InvalidRequest`.

Grandine currently accepts such requests silently ([grandinetech/grandine#686](https://github.com/grandinetech/grandine/issues/686)). Reproducer payload from the bug report:

```
[varint(8)] [snappy(uint64_le(1))] [0xDE 0xAD ... 16 garbage bytes]
```

That wire payload decodes as a valid `Ping`, because the inbound upgrade returns after the first decoded item without checking that the stream is closed. The same reader bug exists in Lighthouse, Prysm, Lodestar, and Nimbus; only Teku is compliant.

## Fix

In `protocol.rs::RPCProtocol::upgrade_inbound`, after `socket.into_future()` yields the first request, poll the framed stream once more with a 500 ms timeout. Clean EOF accepts the request; any further item, or a stream that stays open past the timeout, is rejected as `RPCError::InvalidData`. That routes through the existing handler error path: the offending peer scores `PeerAction::Fatal` and is banned via `peer_manager`.

On the 500 ms timeout: spec-conforming peers half-close the write side via the mplex/yamux substream frame (not TCP FIN), so EOF arrives well under 10 ms in practice. 500 ms covers network jitter without adding meaningful latency to the happy path. Non-conforming peers pay the 500 ms before rejection, which is acceptable because the only path that hits it is the bug path.

## Two intentional limitations

No wire-level `InvalidRequest` chunk is written back. The fix rejects via `RPCError::InvalidData`, which surfaces as a `ListenUpgradeError` rather than going through `inbound_substreams` (the substream is never registered for this failure mode). The peer sees a stream close plus ban rather than an error chunk. Writing a one-shot error chunk from the upgrade-failure path requires restructuring the Framed socket; the spec language ("send back an error message") is satisfied operationally by the ban, and matches how `RPCError::IncompleteStream` is already handled on the same code path. An error-chunk path can land as a follow-up.

Zero-payload requests are not drained. `MetaData V1/V2/V3`, `LightClientOptimisticUpdate`, and `LightClientFinalityUpdate` return from `upgrade_inbound` before reaching the drain branch (they have no SSZ body to decode). Trailing bytes on those request streams are still silently accepted. I'm tracking this as a follow-up to keep the scope here small, and will file a separate issue.

## Tests

Four regression tests added under `rpc::codec::tests`:

- `test_inbound_codec_leaves_trailing_bytes_in_buffer`: codec invariant, sync, at the `BytesMut` level.
- `test_framed_read_yields_extra_chunk_when_trailing_bytes`: `FramedRead`-level check for `Ping` (fixed-size).
- `test_framed_read_reaches_eof_on_clean_request`: non-regression for the clean path.
- `test_framed_read_yields_extra_chunk_when_trailing_bytes_blocks_by_root`: same drain check for a variable-size request.

`cargo test -p eth2_libp2p --lib`: 88/88 pass on aarch64-unknown-linux-gnu (Docker, Rust 1.82) and x86_64-unknown-linux-gnu (Rust 1.95).

## Upstream Lighthouse

The same fix shape (drain after the first decoded item at the protocol-upgrade layer) ports to Lighthouse cleanly, since both implementations share the `tokio_util::codec::Framed`-based RPC plumbing. I'll open a sibling PR there once this one lands.
